### PR TITLE
Adapt to document structure changes as of 2025-03-04

### DIFF
--- a/fa-notification-viewer/index.user.js
+++ b/fa-notification-viewer/index.user.js
@@ -20,8 +20,8 @@ if (window.location.pathname.startsWith('/msg/submissions')) {
 }
 
 function addStartViewerButton() {
-    let gallerySection = document.querySelector('.gallery-section');
-    let buttonsSection = gallerySection.querySelector('div.section-body:nth-child(2) > div:nth-child(1)');
+    let gallerySection = document.evaluate('//section[@class="gallery-section"][2]', document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+    let buttonsSection = gallerySection.querySelector('div.messagecenter-navigation');
     let submissionsAvailable = gallerySection.querySelector('.no-messages') === null;
 
     let startViewerButton = document.createElement('a');


### PR DESCRIPTION
The document structure has changed slightly. Adapt two of the element selectors to match.

Works For Me™, but I've only tested with Tampermonkey on Firefox.

Also, this is the first userscript code I've ever written, so I have no idea if switching from CSS selectors to XPath (to get the second `gallery-section`) is frowned upon.